### PR TITLE
Add require 'etc'

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -2,6 +2,7 @@ require 'net/http'
 require 'uri'
 require 'retryable'
 require 'json'
+require 'etc'
 
 require 'gem/src/srv/configuration'
 


### PR DESCRIPTION
Because if ENV['CONCURRENCY'] doesn't define, `require 'gem/src/src/configuration'` cause error.

---

Thank you for creating a useful gem! 😊 