### PR TITLE
Add webrick for gemspec

### DIFF
--- a/gem-src-srv.gemspec
+++ b/gem-src-srv.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
 
   spec.add_runtime_dependency "retryable", "~> 3.0"
+  spec.add_runtime_dependency "webrick"
 end


### PR DESCRIPTION
Because webrick removed from standard library since Ruby 3.0